### PR TITLE
Correct capitalisation

### DIFF
--- a/wiki/expansion-cards.md
+++ b/wiki/expansion-cards.md
@@ -10,7 +10,7 @@ Framework published electrical and mechanical templates on their GitHub to enabl
 - ESP32-S3 card by [Spacehuhn](https://www.youtube.com/watch?v=IML9c_MsyQU). Available on [GitHub](https://github.com/SpacehuhnTech/framework) or [for purchase](https://spacehuhn.store/products/framework-esp32-s3-expansion-card)
 - Snack Drawer V2 by [XenoCow](https://community.frame.work/u/XenoCow). Available [for purchase](https://layers3d.square.site/) as files or completed part. [^3]
 - Snack Drawer Lite by [XenoCow](https://community.frame.work/u/XenoCow). Available [for download](https://drive.protonmail.com/urls/W2XVGGM1R8#evo86FpGID76). [^4]
-- OpenCom LTE card by [Liberated Embedded Systems](https://liberatedsystems.co.uk). Available [for purchase](https://store.liberatedsystems.co.uk/product/opencom-lte/).
+- openCom LTE card by [Liberated Embedded Systems](https://liberatedsystems.co.uk). Available [for purchase](https://store.liberatedsystems.co.uk/product/opencom-lte/).
 
 # References
 [^1]: <https://community.frame.work/t/expansion-cards-compatible-with-other-devices/990/2?u=morpheus636>


### PR DESCRIPTION
Correct the capitalisation of the openCom LTE.
