### PR TITLE
Automated changes by Wikibot

### DIFF
--- a/wiki/expansion-cards.md
+++ b/wiki/expansion-cards.md
@@ -85,5 +85,5 @@ Framework published electrical and mechanical templates on their GitHub to enabl
 [^8]: <https://knowledgebase.frame.work/displayport-expansion-card-generations-BylqCuwDn> [Archived](http://web.archive.org/web/20250110053953/https://knowledgebase.frame.work/displayport-expansion-card-generations-BylqCuwDn) 
 [^9]: <https://knowledgebase.frame.work/hdmi-expansion-card-generations-Sk7AQKUv2> [Archived](https://web.archive.org/web/20250114051834/https://knowledgebase.frame.work/hdmi-expansion-card-generations-Sk7AQKUv2) 
 [^10]: <https://frame.work/blog/storage-expansion-cards> [Archived](http://web.archive.org/web/20250114034719/https://frame.work/blog/storage-expansion-cards) 
-[^11]: <https://twitter.com/FrameworkPuter/status/1778081340564639855>
+[^11]: <https://twitter.com/FrameworkPuter/status/1778081340564639855> [Archived](http://web.archive.org/web/20241227203213/https://twitter.com/FrameworkPuter/status/1778081340564639855) 
 [^12]: <https://frame.work/blog/introducing-the-new-framework-laptop-13-with-intel-core-ultra-series-1-processors> [Archived](http://web.archive.org/web/20250114032925/https://frame.work/blog/introducing-the-new-framework-laptop-13-with-intel-core-ultra-series-1-processors) 


### PR DESCRIPTION
- Footnote in framework-laptop-13.md contains broken link to https://guides.frame.work/Guide/Framework+Laptop+13+DIY+Edition+Quick+Start+Guide (HTTP Status Code: 404). No archived copy could be located.
