### PR TITLE
Automated changes by Wikibot

### DIFF
--- a/wiki/events/2nd-gen.md
+++ b/wiki/events/2nd-gen.md
@@ -26,6 +26,6 @@ Framework announced the event via a blog post and a scrolling marquee at the top
 <img style="max-width: min(100%, 550px)" src="/assets/2nd-gen-hint.png" alt="Oh *wave*! We've been working on something *color wheel* *woman doing yoga*, something *lightning bolt emoji*, and something worthy of *gathering with friends* *gamepad* *cheetos*. Find out live on Feb 25th at 10:30am PST at the Framework [2nd Gen] event."/>
 
 # References
-[^1]: <https://frame.work/blog/framework-2nd-gen-event-is-live-on-february-25th>
-[^2]: <https://www.youtube.com/live/-8k7jTF_JCg>
+[^1]: <https://frame.work/blog/framework-2nd-gen-event-is-live-on-february-25th> [Archived](https://web.archive.org/web/20250218030820/https://frame.work/blog/framework-2nd-gen-event-is-live-on-february-25th) 
+[^2]: <https://www.youtube.com/live/-8k7jTF_JCg> [Archived](https://web.archive.org/web/20250218031644/https://www.youtube.com/live/-8k7jTF_JCg) 
 [^3]: <https://frame.work> [Archived](https://web.archive.org/web/20250215175138/https://frame.work/)

--- a/wiki/events/next-level.md
+++ b/wiki/events/next-level.md
@@ -52,10 +52,10 @@ Framework announced plans to expand availability to Belgium, Taiwan, Italy and S
 
 
 # References
-[^1]: <https://www.youtube.com/watch?v=WzLybAh1kps>
-[^2]: <https://frame.work/blog/introducing-the-framework-laptop-16-and-both-intel-and-amd-powered-framework-laptop-13>
-[^3]: <https://frame.work/blog/introducing-the-framework-laptop-16>
-[^4]: <https://www.theverge.com/2016/9/7/12838024/apple-iphone-7-plus-headphone-jack-removal-courage>
-[^5]: <https://youtube.com/watch?v=WzLybAh1kps&t=880> Timestamp 14:40. 
-[^6]: <https://youtube.com/watch?v=xwu6FUr14ww&t=124> Timestamp 2:04. 
-[^7]: <https://github.com/FrameworkComputer/Framework-Laptop-13/tree/main/Battery>
+[^1]: <https://www.youtube.com/watch?v=WzLybAh1kps> [Archived](https://web.archive.org/web/20250218030825/https://www.youtube.com/watch?v=WzLybAh1kps) 
+[^2]: <https://frame.work/blog/introducing-the-framework-laptop-16-and-both-intel-and-amd-powered-framework-laptop-13> [Archived](https://web.archive.org/web/20250218031516/https://frame.work/blog/introducing-the-framework-laptop-16-and-both-intel-and-amd-powered-framework-laptop-13) 
+[^3]: <https://frame.work/blog/introducing-the-framework-laptop-16> [Archived](https://web.archive.org/web/20250218031644/https://frame.work/blog/introducing-the-framework-laptop-16) 
+[^4]: <https://www.theverge.com/2016/9/7/12838024/apple-iphone-7-plus-headphone-jack-removal-courage> [Archived](https://web.archive.org/web/20250218032433/https://www.theverge.com/2016/9/7/12838024/apple-iphone-7-plus-headphone-jack-removal-courage) 
+[^5]: <https://youtube.com/watch?v=WzLybAh1kps&t=880> Timestamp 14:40. [Archived](https://web.archive.org/web/20250218032513/https://youtube.com/watch?v=WzLybAh1kps&t=880) 
+[^6]: <https://youtube.com/watch?v=xwu6FUr14ww&t=124> Timestamp 2:04. [Archived](https://web.archive.org/web/20250218032648/https://youtube.com/watch?v=xwu6FUr14ww&t=124) 
+[^7]: <https://github.com/FrameworkComputer/Framework-Laptop-13/tree/main/Battery> [Archived](https://web.archive.org/web/20250218033220/https://github.com/FrameworkComputer/Framework-Laptop-13/tree/main/Battery) 


### PR DESCRIPTION
- Failed to search for archived copy of https://www.youtube.com/watch?v=WzLybAh1kps: Request returned HTTP status code 502
- Failed to search for archived copy of https://frame.work/blog/framework-2nd-gen-event-is-live-on-february-25th: Request returned HTTP status code 502
- Failed to search for archived copy of https://guides.frame.work/Guide/Framework+Laptop+13+DIY+Edition+Quick+Start+Guide: Request returned HTTP status code 502
- Footnote in index.md contains broken link to https://guides.frame.work/Guide/Framework+Laptop+13+DIY+Edition+Quick+Start+Guide (HTTP Status Code: 404). No archived copy could be located.
- Failed to search for archived copy of https://frame.work/blog/introducing-the-framework-laptop-16-and-both-intel-and-amd-powered-framework-laptop-13: Request returned HTTP status code 502
- Failed to search for archived copy of https://www.youtube.com/live/-8k7jTF_JCg: Request returned HTTP status code 502
- Failed to search for archived copy of https://frame.work/blog/introducing-the-framework-laptop-16: Request returned HTTP status code 502
- Failed to search for archived copy of https://www.theverge.com/2016/9/7/12838024/apple-iphone-7-plus-headphone-jack-removal-courage: Request returned HTTP status code 502
- Failed to search for archived copy of https://youtube.com/watch?v=WzLybAh1kps&t=880: Request returned HTTP status code 502
- Failed to search for archived copy of https://youtube.com/watch?v=xwu6FUr14ww&t=124: Request returned HTTP status code 502
- Failed to search for archived copy of https://github.com/FrameworkComputer/Framework-Laptop-13/tree/main/Battery: Request returned HTTP status code 502
