### PR TITLE
Automated changes by Wikibot

### DIFF
--- a/wiki/products/framework-desktop.md
+++ b/wiki/products/framework-desktop.md
@@ -66,6 +66,6 @@ Framework Desktop uses soldered LPDDR5x memory rather than SO-DIMMs, "to enable 
 Framework Desktop supports up to two NVMe M.2 2280 SSDs.[^2] The chassis does not have any 2.5” or 3.5” drive bays, and no SATA ports are present on the mainboard.
 
 # References
-[^1]: <https://www.youtube.com/watch?v=-8k7jTF_JCg>
-[^2]: <https://frame.work/blog/introducing-the-framework-desktop>
-[^3]: <https://frame.work/desktop?tab=specs>
+[^1]: <https://www.youtube.com/watch?v=-8k7jTF_JCg> [Archived](http://web.archive.org/web/20250402013005/https://www.youtube.com/watch?v=-8k7jTF_JCg) 
+[^2]: <https://frame.work/blog/introducing-the-framework-desktop> [Archived](https://web.archive.org/web/20250415185536/https://frame.work/blog/introducing-the-framework-desktop) 
+[^3]: <https://frame.work/desktop?tab=specs> [Archived](http://web.archive.org/web/20250401005454/https://frame.work/desktop?tab=specs) 

--- a/wiki/products/framework-laptop-12.md
+++ b/wiki/products/framework-laptop-12.md
@@ -38,6 +38,6 @@ The Framework Laptop 12 includes a single M.2 2230 slot.[^3]
 Framework Laptop 12 has 4 expansion card ports.[^2]
 
 # References
-[^1]: <https://www.youtube.com/watch?v=-8k7jTF_JCg>
-[^2]: <https://frame.work/blog/introducing-the-framework-laptop-12>
-[^3]: <https://www.youtube.com/watch?v=-lErGZZgUbY>
+[^1]: <https://www.youtube.com/watch?v=-8k7jTF_JCg> [Archived](http://web.archive.org/web/20250402013005/https://www.youtube.com/watch?v=-8k7jTF_JCg) 
+[^2]: <https://frame.work/blog/introducing-the-framework-laptop-12> [Archived](http://web.archive.org/web/20250407150846/https://frame.work/blog/introducing-the-framework-laptop-12) 
+[^3]: <https://www.youtube.com/watch?v=-lErGZZgUbY> [Archived](http://web.archive.org/web/20250411062307/https://www.youtube.com/watch?v=-lErGZZgUbY) 

--- a/wiki/products/framework-laptop-13/ai-300-series.md
+++ b/wiki/products/framework-laptop-13/ai-300-series.md
@@ -62,9 +62,9 @@ Framework Laptop 13 (AMD Ryzen AI 300 Series) supports up to 96GB of DDR5 in two
 Framework Laptop 13 (AMD Ryzen AI 300 Series) supports M.2 2280-size NVMe SSDs.
 
 # References
-[^1]: <https://www.youtube.com/watch?v=-8k7jTF_JCg>
-[^2]: <https://frame.work/blog/introducing-the-framework-laptop-13-powered-by-amd-ryzen-ai-300-series>
-[^3]: <https://frame.work/laptop13?tab=specs>
-[^4]: <https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-5-340.html>
-[^5]: <https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-7-350.html>
+[^1]: <https://www.youtube.com/watch?v=-8k7jTF_JCg> [Archived](http://web.archive.org/web/20250402013005/https://www.youtube.com/watch?v=-8k7jTF_JCg) 
+[^2]: <https://frame.work/blog/introducing-the-framework-laptop-13-powered-by-amd-ryzen-ai-300-series> [Archived](http://web.archive.org/web/20250328102113/https://frame.work/blog/introducing-the-framework-laptop-13-powered-by-amd-ryzen-ai-300-series) 
+[^3]: <https://frame.work/laptop13?tab=specs> [Archived](https://web.archive.org/web/20250415185440/https://frame.work/laptop13?tab=specs) 
+[^4]: <https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-5-340.html> [Archived](http://web.archive.org/web/20250413175207/https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-5-340.html) 
+[^5]: <https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-7-350.html> [Archived](http://web.archive.org/web/20250313085744/https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-7-350.html) 
 [^6]: <https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-9-hx-370.html>

--- a/wiki/products/framework-laptop-13/index.md
+++ b/wiki/products/framework-laptop-13/index.md
@@ -146,5 +146,5 @@ Batch 1 of Core Ultra Series 1 began shipping in August 2024 after it was announ
 [^25]: <https://frame.work/blog/announcing-the-framework-laptop-13-powered-by-amd-ryzen> [Archived](http://web.archive.org/web/20250114040845/https://frame.work/blog/announcing-the-framework-laptop-13-powered-by-amd-ryzen) 
 [^26]: <https://github.com/FrameworkComputer/Framework-Laptop-13/blob/main/Mainboard/Mainboard_Interfaces_Schematic_Intel_Core_Ultra_Series_1.pdf> [Archived](http://web.archive.org/web/20240925161652/https://github.com/FrameworkComputer/Framework-Laptop-13/blob/main/Mainboard/Mainboard_Interfaces_Schematic_Intel_Core_Ultra_Series_1.pdf) 
 [^27]: <https://community.frame.work/t/framework-laptop-13-intel-core-ultra-series-1-bios-3-04-release/59579> [Archived](http://web.archive.org/web/20241127232929/https://community.frame.work/t/framework-laptop-13-intel-core-ultra-series-1-bios-3-04-release/59579) 
-[^28]: <https://frame.work/blog/introducing-the-framework-laptop-13-powered-by-amd-ryzen-ai-300-series>
-[^29]: <https://frame.work/laptop13?tab=specs&slug=laptop13-amd-ai300>
+[^28]: <https://frame.work/blog/introducing-the-framework-laptop-13-powered-by-amd-ryzen-ai-300-series> [Archived](https://web.archive.org/web/20250415185537/https://frame.work/blog/introducing-the-framework-laptop-13-powered-by-amd-ryzen-ai-300-series) 
+[^29]: <https://frame.work/laptop13?tab=specs&slug=laptop13-amd-ai300> [Archived](http://web.archive.org/web/20250415185440/https://frame.work/laptop13?tab=specs) 


### PR DESCRIPTION
- Footnote in ai-300-series.md contains broken link to https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-9-hx-370.html. No archived copy could be located.
