### PR TITLE
AI 300 - Add info about unoficially suppoerted ram.

### DIFF
--- a/wiki/products/framework-laptop-13/ai-300-series.md
+++ b/wiki/products/framework-laptop-13/ai-300-series.md
@@ -55,7 +55,8 @@ Framework Laptop 13 (AMD Ryzen AI 300 Series) comes with the 2nd gen webcam modu
 
 ## Hardware Compatibility
 ### RAM
-Framework Laptop 13 (AMD Ryzen AI 300 Series) supports up to 96GB of DDR5 in two SO-DIMM slots, at up to DDR5-5600 speed. XMP speeds are not supported.[^3]
+Framework Laptop 13 (AMD Ryzen AI 300 Series) oficially supports up to 96GB of DDR5 in two SO-DIMM slots, at up to DDR5-5600 speed. XMP speeds are not supported.[^3]
+It was tested by external vendors that it supports up to 128GB of DDR5 in two SO-DIMM slots.[^8]
 
 ### SSD
 Framework Laptop 13 (AMD Ryzen AI 300 Series) supports M.2 2280-size NVMe SSDs.
@@ -68,3 +69,4 @@ Framework Laptop 13 (AMD Ryzen AI 300 Series) supports M.2 2280-size NVMe SSDs.
 [^5]: <https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-7-350.html> [Archived](http://web.archive.org/web/20250313085744/https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-7-350.html) 
 [^6]: <https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-9-hx-370.html> [Archived](http://web.archive.org/web/20250520162105/https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-9-hx-370.html) 
 [^7]: <https://frame.work/blog/reviews-on-the-new-framework-laptop-13-are-live> [Archived](http://web.archive.org/web/20250418124934/https://frame.work/blog/reviews-on-the-new-framework-laptop-13-are-live) 
+[^8]: <https://www.crucial.com/memory/ddr5/CT2K64G56C46S5/CT26301053> [Archived](https://web.archive.org/web/20250611082636/http://web.archive.org/screenshot/https://www.crucial.com/memory/ddr5/CT2K64G56C46S5/CT26301053)


### PR DESCRIPTION
Framework 13 officially supports only 96 GB of ram, however there are 128GB kits confirmed to work by vendors. I own such kit myself and all ram is detected and usable.