### PR TITLE
Automated changes by Wikibot

### DIFF
--- a/wiki/events/next-gen.md
+++ b/wiki/events/next-gen.md
@@ -22,5 +22,5 @@ Members of the media and [Framework partners](/partners) received invitations to
 
 # References
 [^1]: <https://frame.work/blog/framework-next-gen-event-is-live-on-april-21>
-[^2]: <https://www.youtube.com/watch?v=rgZlzCd0DUU>
+[^2]: <https://www.youtube.com/watch?v=rgZlzCd0DUU> [Archived](https://web.archive.org/web/20260512164025/https://www.youtube.com/watch?v=rgZlzCd0DUU) 
 [^3]: <https://frame.work/nextgen>


### PR DESCRIPTION
- Footnote in next-gen.md contains link to https://frame.work/blog/framework-next-gen-event-is-live-on-april-21, for which no archive is available and none could be created: Wayback Machine reported error:no-request
- Footnote in next-gen.md contains link to https://frame.work/nextgen, for which no archive is available and none could be created: Wayback Machine reported error:no-request
